### PR TITLE
Mention the EFF as a contributor, on the sidebar of theunitedstates.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
 
       <div class="col6">
         <h3 class="col11">
-          <a href="https://github.com/unitedstates/contact-congress">
+          <a href="http://theunitedstates.io/contact-congress">
             /contact-congress
           </a>
         </h3>


### PR DESCRIPTION
This adds the EFF's name to the sidebar, along with Sunlight, GovTrack, and the NYT. This is not meant to be an endorsement of every project in the organization, but a mention of which organizations have meaningfully contributed work here. With the EFF's co-authorship of [/licensing](http://theunitedstates.io/licensing/) and leadership on [/contact-congress](http://theunitedstates.io/contact-congress/), that seemed fair enough to me.

@xor @hainish This seem cool to you?
