### PR TITLE
adding redirect to /APIs/

### DIFF
--- a/apis/index.html
+++ b/apis/index.html
@@ -1,0 +1,4 @@
+<META http-equiv="refresh" content="0;URL=https://theunitedstates.io/APIs/">
+<link rel="canonical" href="https://theunitedstates.io/APIs/" />
+
+This page is redirecting to the US Government API project.  If the page doesn't not redirect you automatically, please <a href="https://theunitedstates.io/APIs/">click here</a>.  


### PR DESCRIPTION
So - I've gone back and forth on this and actually have a reason for keeping the upper case in https://theunitedstates.io/APIs/.  A redirect from https://theunitedstates.io/apis/ will help though.  